### PR TITLE
Add a virtual method that fires on the client right before scene chan…

### DIFF
--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -405,6 +405,9 @@ namespace Mirror
                 NetworkManager.singleton.transport.enabled = false;
             }
 
+            // Let client prepare for scene change
+            OnClientChangeScene(newSceneName);
+
             s_LoadingSceneAsync = SceneManager.LoadSceneAsync(newSceneName);
             networkSceneName = newSceneName;
         }
@@ -745,6 +748,10 @@ namespace Mirror
         public virtual void OnClientNotReady(NetworkConnection conn)
         {
         }
+
+        // Called from ClientChangeScene immediately before SceneManager.LoadSceneAsync is executed
+        // This allows client to do work / cleanup / prep before the scene changes.
+        public virtual void OnClientChangeScene(string newSceneName) { }
 
         public virtual void OnClientSceneChanged(NetworkConnection conn)
         {

--- a/docs/Concepts/Communications/NetworkManager.md
+++ b/docs/Concepts/Communications/NetworkManager.md
@@ -23,6 +23,7 @@ When the host is started:
 -   `OnServerSceneChanged`
 -   `OnServerReady`
 -   `OnServerAddPlayer`
+-   `OnClientChangeScene`
 -   `OnClientSceneChanged`
 
 When a client connects:
@@ -48,6 +49,7 @@ When the client starts:
 -   `Start()` function is called
 -   `OnStartClient`
 -   `OnClientConnect`
+-   `OnClientChangeScene`
 -   `OnClientSceneChanged`
 
 When the client stops:

--- a/docs/Events/Client.md
+++ b/docs/Events/Client.md
@@ -13,6 +13,9 @@ General description of Client Events
 -   **OnClientNotReady**  
     Called on clients when a servers tells the client it is no longer ready.
     This is commonly used when switching Scenes.
+-   **OnClientChangeScene**  
+    Called from ClientChangeScene immediately before SceneManager.LoadSceneAsync is executed.  
+    This allows client to do work / cleanup / prep before the scene changes.
 -   **OnClientSceneChanged**  
     Called on clients when a Scene has completed loading, when the Scene load was initiated by the server.
     Scene changes can cause player objects to be destroyed. The default implementation of OnClientSceneChanged in the NetworkManager is to add a player object for the connection if no player object exists.


### PR DESCRIPTION
…ge so devs can implement client-side work / prep / cleanup / visuals / etc. based on what scene is about to be loaded. (#383)

Documentation updates included.