### PR TITLE
Revert "ClientScene.OnSpawnPrefab and NetworkManager.OnServerAddPlaye…

### DIFF
--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -435,10 +435,6 @@ namespace Mirror
             if (GetPrefab(msg.assetId, out prefab))
             {
                 GameObject obj = Object.Instantiate(prefab, msg.position, msg.rotation);
-
-                // Avoid "(Clone)" suffix. some games do show the name. no need for an extra sync to fix the suffix.
-                obj.name = prefab.name;
-
                 if (LogFilter.Debug)
                 {
                     Debug.Log("Client spawn handler instantiating [netId:" + msg.netId + " asset ID:" + msg.assetId + " pos:" + msg.position + " rotation: " + msg.rotation + "]");

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -692,9 +692,6 @@ namespace Mirror
                 ? Instantiate(playerPrefab, startPos.position, startPos.rotation)
                 : Instantiate(playerPrefab, Vector3.zero, Quaternion.identity);
 
-            // Avoid "(Clone)" suffix. some games do show the name. no need for an extra sync to fix the suffix.
-            player.name = playerPrefab.name;
-
             NetworkServer.AddPlayerForConnection(conn, player);
         }
 


### PR DESCRIPTION
…rInternal: spawn objects with prefab names to avoid unnecessary "(Clone)" suffix from Unity. otherwise we need a name sync component in all games that show the names, e.g. MMOs for all monsters. This way we only need name sync components for objects that actually do change names, e.g. players." because of issue #426

This reverts commit 6a33c2d8bf178015799fcaba4042ec286bbc0b16.